### PR TITLE
add labels for easy cleanup

### DIFF
--- a/persistent-volumes/nfs/pv-template.json
+++ b/persistent-volumes/nfs/pv-template.json
@@ -9,7 +9,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-127m-rox-#NS#"
+        "name": "pvname-127m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -27,7 +30,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-128m-rox-#NS#"
+        "name": "pvname-128m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -45,7 +51,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-129m-rox-#NS#"
+        "name": "pvname-129m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -63,7 +72,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-255m-rox-#NS#"
+        "name": "pvname-255m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -81,7 +93,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-256m-rox-#NS#"
+        "name": "pvname-256m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -99,7 +114,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-257m-rox-#NS#"
+        "name": "pvname-257m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -117,7 +135,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-127m-rwo-#NS#"
+        "name": "pvname-127m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -135,7 +156,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-128m-rwo-#NS#"
+        "name": "pvname-128m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -153,7 +177,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-129m-rwo-#NS#"
+        "name": "pvname-129m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -171,7 +198,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-255m-rwo-#NS#"
+        "name": "pvname-255m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -189,7 +219,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-256m-rwo-#NS#"
+        "name": "pvname-256m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -207,7 +240,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-257m-rwo-#NS#"
+        "name": "pvname-257m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -225,7 +261,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-127m-rwx-#NS#"
+        "name": "pvname-127m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -243,7 +282,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-128m-rwx-#NS#"
+        "name": "pvname-128m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -261,7 +303,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-129m-rwx-#NS#"
+        "name": "pvname-129m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -279,7 +324,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-255m-rwx-#NS#"
+        "name": "pvname-255m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -297,7 +345,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-256m-rwx-#NS#"
+        "name": "pvname-256m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {
@@ -315,7 +366,10 @@
       "kind": "PersistentVolume",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvname-257m-rwx-#NS#"
+        "name": "pvname-257m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "capacity": {

--- a/persistent-volumes/nfs/pvc-template.json
+++ b/persistent-volumes/nfs/pvc-template.json
@@ -9,7 +9,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-1m-rox-#NS#"
+        "name": "pvcname-1m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadOnlyMany" ],
@@ -24,7 +27,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-128m-rox-#NS#"
+        "name": "pvcname-128m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadOnlyMany" ],
@@ -39,7 +45,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-130m-rox-#NS#"
+        "name": "pvcname-130m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadOnlyMany" ],
@@ -54,7 +63,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-258m-rox-#NS#"
+        "name": "pvcname-258m-rox-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadOnlyMany" ],
@@ -69,7 +81,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-1m-rwo-#NS#"
+        "name": "pvcname-1m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteOnce" ],
@@ -84,7 +99,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-128m-rwo-#NS#"
+        "name": "pvcname-128m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteOnce" ],
@@ -99,7 +117,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-130m-rwo-#NS#"
+        "name": "pvcname-130m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteOnce" ],
@@ -114,7 +135,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-258m-rwo-#NS#"
+        "name": "pvcname-258m-rwo-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteOnce" ],
@@ -129,7 +153,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-1m-rwx-#NS#"
+        "name": "pvcname-1m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteMany" ],
@@ -144,7 +171,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-128m-rwx-#NS#"
+        "name": "pvcname-128m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteMany" ],
@@ -159,7 +189,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-130m-rwx-#NS#"
+        "name": "pvcname-130m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteMany" ],
@@ -174,7 +207,10 @@
       "kind": "PersistentVolumeClaim",
       "apiVersion": "v1",
       "metadata": {
-        "name": "pvcname-258m-rwx-#NS#"
+        "name": "pvcname-258m-rwx-#NS#",
+        "labels": {
+            "usedFor": "tc522127"
+        }
       },
       "spec": {
         "accessModes": [ "ReadWriteMany" ],


### PR DESCRIPTION
Automation does not clean-up the PVs which is created via template, add labels for easier clean-up in our steps.