### PR TITLE
update scc volumes

### DIFF
--- a/persistent-volumes/misc/scc.yml
+++ b/persistent-volumes/misc/scc.yml
@@ -33,14 +33,4 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- hostPath
-- nfs
-- persistentVolumeClaim
-- secret
-- rbd
-- iscsi
-- glusterfs
-- gitRepo
+- '*'


### PR DESCRIPTION
using '*' instead of listing all kinds of volumes. We do not need to update the volumes when they change. E.g, one supported volume kind added/removed.