### PR TITLE
config for tc518929

### DIFF
--- a/storage/s3/tc518929/config.yaml
+++ b/storage/s3/tc518929/config.yaml
@@ -1,0 +1,34 @@
+version: 0.1
+log:
+  level: debug
+http:
+  addr: :5000
+storage:
+  cache:
+    layerinfo: inmemory
+version: 0.1
+log:
+  level: debug
+http:
+  addr: :5000
+storage:
+  cache:
+    layerinfo: inmemory
+  s3:
+    accesskey: xxx
+    secretkey: xxx
+    region: us-east-1
+    bucket: openshift-qe-registry-testing-bucket1
+    encrypt: true
+    secure: true
+    v4auth: false
+    rootdirectory: /registry
+auth:
+  openshift:
+    realm: openshift
+middleware:
+  repository:
+    - name: openshift
+      options:
+
+        pullthrough: true


### PR DESCRIPTION
currently the s3 creds are represented by a placeholder 'xxx', will need to replace them with actual value at runtime.