### PR TITLE
Update prometheus.yml

### DIFF
--- a/routing/prometheus/prometheus.yml
+++ b/routing/prometheus/prometheus.yml
@@ -3,6 +3,6 @@
  
  scrape_configs:
    - job_name: "haproxy"
-     target_groups:
+     static_configs:
      - targets:
          - "nodeip:9101"


### PR DESCRIPTION
target_groups has been replaced with static_configs since prometheus v0.20