### PR TITLE
Tcms497874 hotfix

### DIFF
--- a/build/stibuild-configchange.json
+++ b/build/stibuild-configchange.json
@@ -349,36 +349,6 @@
         "strategy": {
           "type": "Recreate",
           "recreateParams": {
-            "pre": {
-              "failurePolicy": "Abort",
-              "execNewPod": {
-                "command": [
-                  "/bin/true"
-                ],
-                "env": [
-                  {
-                    "name": "CUSTOM_VAR1",
-                    "value": "custom_value1"
-                  }
-                ],
-                "containerName": "php-helloworld-database"
-              }
-            },
-            "post": {
-              "failurePolicy": "Ignore",
-              "execNewPod": {
-                "command": [
-                  "/bin/false"
-                ],
-                "env": [
-                  {
-                    "name": "CUSTOM_VAR2",
-                    "value": "custom_value2"
-                  }
-                ],
-                "containerName": "php-helloworld-database"
-              }
-            }
           },
           "resources": {}
         },

--- a/build/stibuild-configchange.json
+++ b/build/stibuild-configchange.json
@@ -483,7 +483,7 @@
             "name": "VOLUME_CAPACITY",
             "value": "1Gi",
             "required": true
-	  }
+    }
   ],
   "labels": {
     "template": "application-template-stibuild"

--- a/build/stibuild-configchange.json
+++ b/build/stibuild-configchange.json
@@ -409,6 +409,12 @@
                     "protocol": "TCP"
                   }
                 ],
+                "volumeMounts": [
+                  {
+                    "mountPath": "/var/lib/mysql/data",
+                    "name": "database-mysql-pvol"
+                  }
+                ],
                 "env": [
                   {
                     "name": "MYSQL_USER",
@@ -432,13 +438,41 @@
                 }
               }
             ],
+            "volumes": [
+              {
+                "name": "database-mysql-pvol",
+                "persistentVolumeClaim": {
+                  "claimName": "database-mysql-claim"
+                }
+              }
+            ],
             "restartPolicy": "Always",
             "dnsPolicy": "ClusterFirst"
           }
         }
       },
       "status": {}
-    }
+    },
+    {
+          "apiVersion": "v1",
+          "kind": "PersistentVolumeClaim",
+          "metadata": {
+              "name": "database-mysql-claim",
+              "labels": {
+                  "application": "database"
+              }
+          },
+          "spec": {
+              "accessModes": [
+                  "ReadWriteOnce"
+              ],
+              "resources": {
+                  "requests": {
+                      "storage": "${VOLUME_CAPACITY}"
+                  }
+              }
+          }
+  }
   ],
   "parameters": [
     {
@@ -472,7 +506,14 @@
       "description": "database name",
       "value": "root",
       "required": true
-    }
+    },
+    {
+            "description": "Size of persistent storage for database volume.",
+            "displayName": "Volume Capacity",
+            "name": "VOLUME_CAPACITY",
+            "value": "1Gi",
+            "required": true
+	  }
   ],
   "labels": {
     "template": "application-template-stibuild"


### PR DESCRIPTION
This change implements several things for TCMS case #497874:

- first, the case was failing in the Online environment, as the template pre/post deployment hooks did not contain a volume mount point, as such, docker tries to create a local volume, and is denied. To my knowledge, neither of these hooks are needed, and therefore removed.
- second, and for similar reasons above, the template did not contain a proper mysql mount, pv or pvc, and therefore those are added with this PR. 