### PR TITLE
Online env has some memory cpu limits 

### DIFF
--- a/image/language-image-templates/tc521461/template.json
+++ b/image/language-image-templates/tc521461/template.json
@@ -129,16 +129,6 @@
                 "protocol": "TCP"
               }
             ],
-            "resources": {
-              "limits": {
-                "cpu": "800m",
-                "memory": "100Mi"
-              },
-              "requests": {
-                "cpu": "600m",
-                "memory": "100Mi"
-              }
-            },
             "terminationMessagePath": "/dev/termination-log",
             "imagePullPolicy": "Always"
           }

--- a/image/language-image-templates/tc521462/template.json
+++ b/image/language-image-templates/tc521462/template.json
@@ -128,16 +128,6 @@
                 "protocol": "TCP"
               }
             ],
-            "resources": {
-              "limits": {
-                "cpu": "800m",
-                "memory": "100Mi"
-              },
-              "requests": {
-                "cpu": "600m",
-                "memory": "100Mi"
-              }
-            },
             "terminationMessagePath": "/dev/termination-log",
             "imagePullPolicy": "Always"
           }

--- a/templates/OCP-12297/trigger_deployment_failed.groovy
+++ b/templates/OCP-12297/trigger_deployment_failed.groovy
@@ -1,4 +1,4 @@
 node{
         stage 'build' 
-        def deploy = openshiftDeploy apiURL: '<repl_env>', authToken: '', depCfg: 'frontend', namespace: '<repl_ns>', verbose: 'false', waitTime: '1ms', waitUnit: 'sec'
+        def deploy = openshiftDeploy apiURL: '<repl_env>', authToken: '', depCfg: 'frontend', namespace: '<repl_ns>', verbose: 'false', waitTime: '1', waitUnit: 'sec'
 }

--- a/templates/OCP-12297/trigger_deployment_failed.groovy
+++ b/templates/OCP-12297/trigger_deployment_failed.groovy
@@ -1,4 +1,4 @@
 node{
         stage 'build' 
-        def deploy = openshiftDeploy apiURL: '<repl_env>', authToken: '', depCfg: 'frontend', namespace: '<repl_ns>', verbose: 'false', waitTime: '1', waitUnit: 'sec'
+        def deploy = openshiftDeploy apiURL: '<repl_env>', authToken: '', depCfg: 'frontend', namespace: '<repl_ns>', verbose: 'false', waitTime: '1ms', waitUnit: 'sec'
 }


### PR DESCRIPTION
when creating app with those template on online env, there some error message when deploy:
```console 
-->  FailedCreate: rails-ex-1 Error creating: pods "rails-ex-1-" is forbidden: [minimum memory usage per Pod is 204Mi, but request is 62914560., minimum cpu usage per Pod is 39m, but request is 11m., minimum cpu usage per Container is 39m, but request is 11m., minimum memory usage per Container is 204Mi, but request is 60Mi.]
-->  FailedCreate: rails-ex-1 Error creating: pods "rails-ex-1-" is forbidden: [minimum memory usage per Pod is 204Mi, but request is 62914560., minimum cpu usage per Pod is 39m, but request is 11m., minimum memory usage per Container is 204Mi, but request is 60Mi., minimum cpu usage per Container is 39m, but request is 11m.]
-->  FailedCreate: rails-ex-1 Error creating: pods "rails-ex-1-" is forbidden: [minimum cpu usage per Pod is 39m, but request is 11m., minimum memory usage per Pod is 204Mi, but request is 62914560., minimum cpu usage per Container is 39m, but request is 11m., minimum memory usage per Container is 204Mi, but request is 60Mi.]
error: couldn't scale rails-ex-1 to 1: timed out waiting for "rails-ex-1" to be synced
```
I think remove those resources limits does not effect our checkpoint, see OCP-10810 OCP-11257 @wanghaoran1988 WDYT ?


