### PR TITLE
Update image for dapi-keys-permission-pod

### DIFF
--- a/pods/permission-data/dapi-keys-permission-pod.yaml
+++ b/pods/permission-data/dapi-keys-permission-pod.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: client-container
-      image: redis
+      image: docker.io/ocpqe/hello-pod:latest
       securityContext:
         privileged: false
       volumeMounts:


### PR DESCRIPTION
In online failed with: http://ci-qe-openshift.nay.redhat.com/userContent/cucushift/v3/2017/08/15/03:26:27/Permission_mode_work_well_in_privileged_policy_with_fsGroup/console.html
detail: http://pastebin.test.redhat.com/508352