### PR TITLE
Modify source build code to ruby-ex for ruby:2.2 and ruby:2.0

### DIFF
--- a/image/language-image-templates/OCP-13136/template.json
+++ b/image/language-image-templates/OCP-13136/template.json
@@ -41,7 +41,7 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://github.com/openshift/rails-ex"
+                "uri": "https://github.com/openshift/ruby-ex"
             },
             "secrets": []
         },

--- a/image/language-image-templates/tc521461/template.json
+++ b/image/language-image-templates/tc521461/template.json
@@ -41,8 +41,7 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://github.com/openshift/rails-ex",
-                "ref": "16716f4ae876836db25ff8ab235e49d04a52c2f9"
+                "uri": "https://github.com/openshift/ruby-ex"
             },
             "secrets": []
         },

--- a/image/language-image-templates/tc521462/template.json
+++ b/image/language-image-templates/tc521462/template.json
@@ -41,7 +41,7 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://github.com/openshift/rails-ex"
+                "uri": "https://github.com/openshift/ruby-ex"
             },
             "secrets": []
         },


### PR DESCRIPTION
rails-ex repo has not supported below ruby 2.2 versions, so modify using this repo to ruby-ex repo.