### PR TITLE
Update snapshot api to align with upstream

### DIFF
--- a/persistent-volumes/snapshot/snapshot-role.yaml
+++ b/persistent-volumes/snapshot/snapshot-role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: volumesnapshot-admin
 rules:
 - apiGroups:
-  - "volume-snapshot-data.external-storage.k8s.io"
+  - "volumesnapshot.external-storage.k8s.io"
   attributeRestrictions: null
   resources:
   - volumesnapshots

--- a/persistent-volumes/snapshot/snapshot.yaml
+++ b/persistent-volumes/snapshot/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-1


### PR DESCRIPTION
Align the api change with upstream,
https://github.com/kubernetes-incubator/external-storage/blob/master/snapshot/doc/user-guide.md