### PR TITLE
Fix OCP-10602 host

### DIFF
--- a/routing/tc/tc477695/hello.json
+++ b/routing/tc/tc477695/hello.json
@@ -31,7 +31,6 @@
                 "name": "hello-route"
             },
             "spec": {
-                "host": "www.hello.com",
                 "path": "/testpath1",
                 "to": {
                     "kind": "Service",

--- a/routing/tc/tc477695/new_route.json
+++ b/routing/tc/tc477695/new_route.json
@@ -5,7 +5,6 @@
         "name": "hello-route1"
     },
     "spec": {
-        "host": "www.hello1.com",
         "to": {
             "kind": "Service",
             "name": "hello-service"


### PR DESCRIPTION
Updating for https://github.com/openshift/cucushift/pull/5818 for Online env due to failure:
```
When I process and create "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/routing/tc/tc477695/hello.json"
The Route "hello-route" is invalid: spec.host: Forbidden: you do not have permission to set the host field of the route
```
@yapei please merge, thanks