### PR TITLE
Change slave node to jenkins master

### DIFF
--- a/templates/OCP-11344/samplepipeline.yaml
+++ b/templates/OCP-11344/samplepipeline.yaml
@@ -105,18 +105,15 @@ objects:
   spec:
     strategy:
       jenkinsPipelineStrategy:
-        env:
-        - name: VAR1
-          value: value1
         jenkinsfile: |-
           try {
              timeout(time: 20, unit: 'MINUTES') {
                 node {
-                    stage('echo env') {
-                      echo "VAR1 = ${env.VAR1}"
-                      echo "VAR2 = ${env.VAR2}"
-                      echo "VAR3 = ${env.VAR3}"
-                      echo "VAR4 = ${env.VAR4}"
+                    stage('build') {
+                      openshiftBuild(buildConfig: '${NAME}', showBuildLogs: 'true')
+                    }
+                    stage('deploy') {
+                      openshiftDeploy(deploymentConfig: '${NAME}')
                     }
                   }
              }

--- a/templates/tc531203/samplepipeline.json
+++ b/templates/tc531203/samplepipeline.json
@@ -238,7 +238,7 @@
             }
           }
         ],
-        "replicas": 2,
+        "replicas": 1,
         "selector": {
           "name": "frontend"
         },


### PR DESCRIPTION
Since the default configuare for slave node in jenkins are using v3.9 tag for release registry, it can't fetch before release. So modify the sample pipeline to use jenkins master.