### PR TITLE
Change cert-dir to for api-server

### DIFF
--- a/logging_metrics/secure_heapster/heapster_grafana_influxdb.yaml
+++ b/logging_metrics/secure_heapster/heapster_grafana_influxdb.yaml
@@ -102,6 +102,7 @@ spec:
         - --requestheader-username-headers=X-Remote-User
         - --requestheader-group-headers=X-Remote-Group
         - --requestheader-extra-headers-prefix=X-Remote-Extra-
+        - --cert-dir=/tmp
         volumeMounts:
         - mountPath: /var/run/kubernetes
           name: ca


### PR DESCRIPTION
change cert-dir from /var/run/kubernetes to /tmp since /var/run/kubernetes is mounted as RO, so new generated cert can not be touched in the dir.