### PR TITLE
adding new file dns-egresspolicy3

### DIFF
--- a/networking/egress-ingress/dns-egresspolicy3.json
+++ b/networking/egress-ingress/dns-egresspolicy3.json
@@ -1,0 +1,23 @@
+{
+    "kind": "EgressNetworkPolicy",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "policy-test"
+    },
+    "spec": {
+        "egress": [
+            {
+                "type": "Deny",
+                "to": {
+                    "dnsName": "google.com"
+                }
+            },
+            {
+                "type": "Allow",
+                "to": {
+                  "cidrSelector": "98.138.0.0/16"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adding new file dns-egresspolicy3 for updating OCP-13509 which need >=3 IPs from dns lookup.
Before `yahoo.com` is OK but recently it just return 2 IPs, so add this file with `google.com`.

@bmeng please help review and merge. thanks