### PR TITLE
update buildconfig template

### DIFF
--- a/build/tc517367/test-buildconfig.json
+++ b/build/tc517367/test-buildconfig.json
@@ -41,7 +41,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/ruby-20-centos7:latest"
+          "name": "docker.io/centos/ruby-23-centos7:latest"
         }
       },
       "env": [

--- a/build/tc517369/test-buildconfig.json
+++ b/build/tc517369/test-buildconfig.json
@@ -42,7 +42,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/ruby-20-centos7:latest"
+          "name": "docker.io/centos/ruby-23-centos7:latest"
         }
       },
       "env": [

--- a/build/tc517370/test-buildconfig.json
+++ b/build/tc517370/test-buildconfig.json
@@ -41,7 +41,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/openshift/ruby-20-centos7:latest"
+          "name": "docker.io/centos/ruby-23-centos7:latest"
         }
       },
       "env": [


### PR DESCRIPTION
use ruby23 image as base image instead of ruby20, due to ruby-hello-world repo does not support ruby2.0 any more