### PR TITLE
update secrect type for TLS ingress

### DIFF
--- a/routing/ingress/mysecret.json
+++ b/routing/ingress/mysecret.json
@@ -8,5 +8,5 @@
     "metadata": {
         "name": "mysecret"
     },
-    "type": "Opaque"
+    "type": "kubernetes.io/tls"
 }


### PR DESCRIPTION
The secret "Opaque" type for ingress doesn't work in OCP 3.10.
Although the Ingress official document ( https://kubernetes.io/docs/concepts/services-networking/ingress/#tls ) give an example which using "Opaque" type but more other examples (e.g. https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls ) which using "kubernetes.io/tls" type in secret for ingress, and it is more reasonable I think.

Update to "kubernetes.io/tls" type and it works well in both 3.10 and previous release.

@bmeng @zhaozhanqi Please help review.