### PR TITLE
Revert "update the service port"

### DIFF
--- a/routing/ingress/path-ingress.json
+++ b/routing/ingress/path-ingress.json
@@ -13,7 +13,7 @@
                         {
                             "backend": {
                                 "serviceName": "service-unsecure",
-                                "servicePort": 27017
+                                "servicePort": 8080
                             },
                             "path": "/test"
                         }

--- a/routing/ingress/test-ingress.json
+++ b/routing/ingress/test-ingress.json
@@ -13,7 +13,7 @@
                         {
                             "backend": {
                                 "serviceName": "service-unsecure",
-                                "servicePort": 27017
+                                "servicePort": 8080
                             }
                         }
                     ]

--- a/routing/ingress/tls-ingress.json
+++ b/routing/ingress/tls-ingress.json
@@ -13,7 +13,7 @@
                         {
                             "backend": {
                                 "serviceName": "service-unsecure",
-                                "servicePort": 27017
+                                "servicePort": 8080
                             },
                             "path": "/"
                         }


### PR DESCRIPTION
Reverts openshift-qe/v3-testfiles#845

@zhaozhanqi @bmeng As we discussed I'd like to revert this for old version testing.

For 3.10 and later, we can try use  `oc create service` or create new ingress file to use the right port.

FYI.
https://bugzilla.redhat.com/show_bug.cgi?id=1571133#c2
