### PR TITLE
Security test which use pvc, instead of volume directly

### DIFF
--- a/persistent-volumes/security/privileged-test.json
+++ b/persistent-volumes/security/privileged-test.json
@@ -1,0 +1,55 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mypod",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "volume-test"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "c1",
+        "image": "jhou/hello-openshift",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {},
+        "volumeMounts": [
+          {
+            "name":"myvolume",
+            "mountPath":"/mnt"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "securityContext": {
+          "privileged": true
+        }
+      }
+    ],
+    "securityContext": {
+         "fsGroup": 123456,
+         "seLinuxOptions": {
+            "level": "s0:c13,c2"
+         }
+    },
+    "volumes": [
+      {
+          "name": "myvolume",
+          "persistentVolumeClaim": {
+              "claimName": "myclaim"
+          }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}

--- a/persistent-volumes/security/selinux-fsgroup-test.json
+++ b/persistent-volumes/security/selinux-fsgroup-test.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mypod",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "volume-test"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "c1",
+        "image": "jhou/hello-openshift",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {},
+        "volumeMounts": [
+          {
+            "name":"myvolume",
+            "mountPath":"/mnt/"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "securityContext": {
+          "privileged": false
+        }
+      }
+    ],
+    "securityContext": {
+         "fsGroup": 123456,
+         "runAsUser": 1000160000,
+         "seLinuxOptions": {
+            "level": "s0:c13,c2"
+         }
+    },
+    "volumes": [
+      {
+          "name": "myvolume",
+          "persistentVolumeClaim": {
+              "claimName": "myclaim"
+          }
+      }
+    ],
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}


### PR DESCRIPTION
Copied from https://github.com/openshift-qe/v3-testfiles/tree/master/persistent-volumes/gce/security
and updated
```
    "volumes": [
      {
          "name": "gcepd",
          "gcePersistentDisk": {
              "pdName": "my-data-disk",
              "fsType": "ext4"
          }
      }
    ],
```
to
```
    "volumes": [
      {
          "name": "myvolume",
          "persistentVolumeClaim": {
              "claimName": "myclaim"
          }
      }
    ],

```