### PR TITLE
Lower api version to support 3.7

### DIFF
--- a/storage/snapshot/ClusterRole-controller.yaml
+++ b/storage/snapshot/ClusterRole-controller.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: snapshot-controller-role
 rules:


### PR DESCRIPTION
@jhou1  

Tested v1beta1 on 3.7/3.10/3.11, both works.