### PR TITLE
Updated postcommit to apply for 4.0 version

### DIFF
--- a/build/ruby20rhel7-template-docker.json
+++ b/build/ruby20rhel7-template-docker.json
@@ -142,7 +142,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/ruby20rhel7-template-sti.json
+++ b/build/ruby20rhel7-template-sti.json
@@ -144,7 +144,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/ruby22-imageupgrade-stibuild.json
+++ b/build/ruby22-imageupgrade-stibuild.json
@@ -144,7 +144,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/ruby22rhel7-env-sti.json
+++ b/build/ruby22rhel7-env-sti.json
@@ -152,7 +152,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/ruby22rhel7-template-docker.json
+++ b/build/ruby22rhel7-template-docker.json
@@ -142,7 +142,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/ruby22rhel7-template-sti.json
+++ b/build/ruby22rhel7-template-sti.json
@@ -144,7 +144,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/tc470422/application-template-stibuild.json
+++ b/build/tc470422/application-template-stibuild.json
@@ -154,7 +154,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/tc476354/pushimage.json
+++ b/build/tc476354/pushimage.json
@@ -89,7 +89,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/tc479297/test-template-dockerbuild.json
+++ b/build/tc479297/test-template-dockerbuild.json
@@ -52,7 +52,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/build/tc482273/test-template-stibuild.json
+++ b/build/tc482273/test-template-stibuild.json
@@ -52,7 +52,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/OCP-11417/ruby22rhel7-template-sti-wrong-source.json
+++ b/templates/OCP-11417/ruby22rhel7-template-sti-wrong-source.json
@@ -144,7 +144,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/OCP-11417/ruby22rhel7-template-sti.json
+++ b/templates/OCP-11417/ruby22rhel7-template-sti.json
@@ -144,7 +144,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
+++ b/templates/OCP-12057/application-template-stibuild_pull_private_sourceimage.json
@@ -170,7 +170,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc479059/application-template-parameters.json
+++ b/templates/tc479059/application-template-parameters.json
@@ -97,7 +97,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc515804/application-template-stibuild.json
+++ b/templates/tc515804/application-template-stibuild.json
@@ -145,7 +145,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc517666/ruby22rhel7-template-sti.json
+++ b/templates/tc517666/ruby22rhel7-template-sti.json
@@ -160,7 +160,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc517667/ruby22rhel7-template-sti.json
+++ b/templates/tc517667/ruby22rhel7-template-sti.json
@@ -174,7 +174,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc517668/ruby22rhel7-template-docker.json
+++ b/templates/tc517668/ruby22rhel7-template-docker.json
@@ -153,7 +153,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/tc531203/samplepipeline.json
+++ b/templates/tc531203/samplepipeline.json
@@ -168,7 +168,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/ui/application-template-dockerbuild-without-customize-route.json
+++ b/templates/ui/application-template-dockerbuild-without-customize-route.json
@@ -154,7 +154,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/ui/application-template-dockerbuild.json
+++ b/templates/ui/application-template-dockerbuild.json
@@ -155,7 +155,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/ui/application-template-stibuild-without-customize-route.json
+++ b/templates/ui/application-template-stibuild-without-customize-route.json
@@ -154,7 +154,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/templates/ui/application-template-stibuild.json
+++ b/templates/ui/application-template-stibuild.json
@@ -155,7 +155,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },


### PR DESCRIPTION
Now in 4.0 version it's not support args in postcommit, so updated using script, and updated files works in 3.11 ....