### PR TITLE
Test file required for OCP-19810

### DIFF
--- a/networking/pod_with_udp_port_listener.json
+++ b/networking/pod_with_udp_port_listener.json
@@ -1,0 +1,36 @@
+{
+    "apiVersion": "v1",
+    "kind": "List",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+                "labels": {
+                    "name": "udp-rc"
+                },
+                "name": "udp-rc"
+            },
+            "spec": {
+                "replicas": 1,
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "name": "udp-pods"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                              "command": [ "/usr/bin/ncat", "-u", "-l", "8080","--keep-open", "--exec", "/bin/cat"],
+                              "name": "udp-pod",
+                              "image": "aosqe/pod-for-ping"
+                            }
+                        ],
+                 "restartPolicy": "Always"
+                    }
+                }
+            }
+       }
+    ]
+}


### PR DESCRIPTION
This file is required for testing OCP-19810. This json file creates a pod with udp port listening in the user project with the help of ncat tool and have replicas value set to 1 to simulate recreation in case the pod gets deleted.
