### PR TITLE
Group and version changes of Marketplace APIs

### DIFF
--- a/logging/clusterlogging/OCP-21311/catalogsorceconfig.yaml
+++ b/logging/clusterlogging/OCP-21311/catalogsorceconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: "marketplace.redhat.com/v1alpha1"
+apiVersion: "operators.coreos.com/v1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "cluster-logging"

--- a/logging/clusterlogging/csc-clusterlogigng.yaml
+++ b/logging/clusterlogging/csc-clusterlogigng.yaml
@@ -1,4 +1,4 @@
-apiVersion: marketplace.redhat.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: CatalogSourceConfig
 metadata:
   name: installed-community-openshift-logging

--- a/logging/clusterlogging/csc-elasticsearch.yaml
+++ b/logging/clusterlogging/csc-elasticsearch.yaml
@@ -1,4 +1,4 @@
-apiVersion: marketplace.redhat.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: CatalogSourceConfig
 metadata:
   name: installed-community-openshift-operators

--- a/metering/OLM_examples/metering-catalogsourceconfig.yaml
+++ b/metering/OLM_examples/metering-catalogsourceconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: "marketplace.redhat.com/v1alpha1"
+apiVersion: "operators.coreos.com/v1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "metering"


### PR DESCRIPTION
@pruan-rht  @QiaolingTang 
Change group/version of OperatorSource/CatalogSourceConfig to operators.coreos.com/v1 from marketplace.redhat.com/v1alpha1

Reference to http://post-office.corp.redhat.com/archives/aos-devel/2019-March/msg00580.html