### PR TITLE
Remove unused securityContext from OCP-10143

### DIFF
--- a/storage/iscsi/pod-two-luns.json
+++ b/storage/iscsi/pod-two-luns.json
@@ -36,14 +36,6 @@
                 }]
             }
         ],
-        "securityContext": {
-            "runAsUser": 1010,
-            "supplementalGroups": [1,2,3,4,5,6],
-            "fsGroup": 123456,
-            "seLinuxOptions": {
-                 "level": "s0:c1,c5"
-             }
-        },
         "volumes": [
             {
                 "name": "iscsi-rw",


### PR DESCRIPTION
Test file storage/iscsi/pod-two-luns.json is only used by test case OCP-10143, which does not do securityContext check.
```
$ pwd
/home/lxia/github.com/verification-tests
$ grep -r 'iscsi/pod-two-luns' *
features/tierN/storage/iscsi.feature:    When I run oc create over "https://raw.githubusercontent.com/openshift-qe/v3-testfiles/master/storage/iscsi/pod-two-luns.json" replacing paths:
```
SecurityContext check for iSCSI is done in test case [OCP-9638](https://github.com/openshift/verification-tests/blob/master/features/storage/iscsi.feature#L4), which uses test file [pod.json](https://raw.githubusercontent.com/openshift-qe/docker-iscsi/master/pod.json) 

@jhou1 @weherdh @chao007 