### PR TITLE
Add 6443 for squid proxy conf

### DIFF
--- a/dockerfiles/squid-proxy/latest/squid_auth.conf
+++ b/dockerfiles/squid-proxy/latest/squid_auth.conf
@@ -16,6 +16,7 @@ acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machine
 
 acl SSL_ports port 443
 acl SSL_ports port 8443
+acl SSL_ports port 6443
 acl Safe_ports port 80		# http
 acl Safe_ports port 21		# ftp
 acl Safe_ports port 443		# https


### PR DESCRIPTION
Case OCP-11564 failed. https://bugzilla.redhat.com/show_bug.cgi?id=1663453#c1 pointed out the cause:
"internal proxies allow CONNECT on 8443 but don't seem to allow this on 6443"

So fixing it for the case. Pass log: job/Runner-v3/42623/console . @zhouying7780 