### PR TITLE
adding subscription template files for logging automation testing

### DIFF
--- a/logging/clusterlogging/deploy_clo_via_olm/4.2/clo-sub-template.yaml
+++ b/logging/clusterlogging/deploy_clo_via_olm/4.2/clo-sub-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: cluster-logging
+    namespace: openshift-logging
+  spec:
+    channel: "${CHANNEL}"
+    installPlanApproval: Automatic
+    name: cluster-logging
+    source: ${SOURCE}
+    sourceNamespace: openshift-marketplace
+parameters:
+  - name: SOURCE
+  - name: CHANNEL

--- a/logging/eleasticsearch/deploy_via_olm/4.2/eo-sub-template.yaml
+++ b/logging/eleasticsearch/deploy_via_olm/4.2/eo-sub-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: elasticsearch-operator
+    namespace: openshift-operators-redhat
+  spec:
+    channel: "${CHANNEL}"
+    installPlanApproval: Automatic
+    name: elasticsearch-operator
+    source: ${SOURCE}
+    sourceNamespace: openshift-marketplace
+parameters:
+  - name: SOURCE
+  - name: CHANNEL


### PR DESCRIPTION
@anpingli  PTAL

I'm adding these 2 files to make the automation test more flexible.

When launch job to run the automation test, no matter what the name of opsrc is and no matter which version of logging we want to test, we just need to set some env vars, e.g.:
```
export BUSHSLICER_CONFIG='                                                        
environments:
  ocp4:
    version: "4.3"
    subscription_opsrc_name: "redhat-operators-art"
```