### PR TITLE
Fix OCP-16295 volume mount path cannot be system path /etc

### DIFF
--- a/templates/tc467937/pod467937-new.yaml
+++ b/templates/tc467937/pod467937-new.yaml
@@ -1,6 +1,5 @@
 kind: Pod
 apiVersion: v1
-id: kurbernetes-metadata-volume-plugin
 metadata:
   labels:
     zone: us-est-coast
@@ -17,7 +16,7 @@ spec:
       command: ["sh", "-c", "while true; do if [[ -e /etc/labels ]]; then cat /etc/labels; fi; if [[ -e /etc/annotations ]]; then cat /etc/annotations; fi; sleep 5; done"]
       volumeMounts:
         - name: podinfo
-          mountPath: /etc
+          mountPath: /data/podinfo-dir
           readOnly: false
   volumes:
     - name: podinfo


### PR DESCRIPTION
The case failed in our CI runs: [failure log](https://url.corp.redhat.com/ff3d1e4).
```
Given the pod named "kubernetes-metadata-volume-example" becomes ready
12:39:15 INFO> oc get pods kubernetes-metadata-volume-example --output=yaml ...
...
          container create failed: container_linux.go:345: starting container process caused 
"process_linux.go:430: container init caused \"rootfs_linux.go:58: mounting \\\"/var/lib/kubelet
/pods/461daf19-ffc9-11e9-b488-02cbe657c478/etc-hosts\\\" to rootfs \\\"/var/lib/containers/storage
/overlay/5e8480c5de374cbd32b63237b92307ec76856e7ca7f3510f0decb4f4bb3850ca/merged\\\" at
 \\\"/var/lib/containers/storage/overlay/5e8480c5de374cbd32b63237b92307ec76856e7ca7f3510f0decb4f4bb3850ca/merged/etc/hosts\\\" 
caused \\\"open /var/lib/containers/storage/overlay
/5e8480c5de374cbd32b63237b92307ec76856e7ca7f3510f0decb4f4bb3850ca/merged/etc/hosts: read-
only file system\\\"\""
        reason: CreateContainerError
  phase: Pending
...
kubernetes-metadata-volume-example pod did not become ready
```