### PR TITLE
change inputType to inputSource

### DIFF
--- a/logging/logforwarding/elasticsearch/insecure/logforwarding-elasticsearch-insecure.yaml
+++ b/logging/logforwarding/elasticsearch/insecure/logforwarding-elasticsearch-insecure.yaml
@@ -11,14 +11,14 @@ spec:
       insecure: true
   pipelines:
     - name: app-pipeline
-      inputType: logs.app
+      inputSource: logs.app
       outputRefs:
         - user-created-es
     - name: infra-pipeline
-      inputType: logs.infra
+      inputSource: logs.infra
       outputRefs:
         - user-created-es
     - name: audit-pipeline
-      inputType: logs.audit
+      inputSource: logs.audit
       outputRefs:
         - user-created-es

--- a/logging/logforwarding/elasticsearch/secure/logforwarding-elasticsearch.yaml
+++ b/logging/logforwarding/elasticsearch/secure/logforwarding-elasticsearch.yaml
@@ -12,14 +12,14 @@ spec:
         name: piplinesecret
   pipelines:
     - name: app-pipeline
-      inputType: logs.app
+      inputSource: logs.app
       outputRefs:
         - user-created-es
     - name: infra-pipeline
-      inputType: logs.infra
+      inputSource: logs.infra
       outputRefs:
         - user-created-es
     - name: audit-pipeline
-      inputType: logs.audit
+      inputSource: logs.audit
       outputRefs:
         - user-created-es

--- a/logging/logforwarding/fluentd/insecure/logforwarding-insecure.yaml
+++ b/logging/logforwarding/fluentd/insecure/logforwarding-insecure.yaml
@@ -11,14 +11,14 @@ spec:
       insecure: true
   pipelines:
     - name: app-pipeline
-      inputType: logs.app
+      inputSource: logs.app
       outputRefs:
         - fluentd-created-by-user
     - name: infra-pipeline
-      inputType: logs.infra
+      inputSource: logs.infra
       outputRefs:
         - fluentd-created-by-user
     - name: audit-pipeline
-      inputType: logs.audit
+      inputSource: logs.audit
       outputRefs:
         - fluentd-created-by-user

--- a/logging/logforwarding/fluentd/secure/logforwarding-secure.yaml
+++ b/logging/logforwarding/fluentd/secure/logforwarding-secure.yaml
@@ -12,14 +12,14 @@ spec:
         name: fluentdserver
   pipelines:
     - name: app-pipeline
-      inputType: logs.app
+      inputSource: logs.app
       outputRefs:
         - fluentd-created-by-user
     - name: infra-pipeline
-      inputType: logs.infra
+      inputSource: logs.infra
       outputRefs:
         - fluentd-created-by-user
     - name: audit-pipeline
-      inputType: logs.audit
+      inputSource: logs.audit
       outputRefs:
         - fluentd-created-by-user


### PR DESCRIPTION
Per https://github.com/openshift/cluster-logging-operator/blob/master/pkg/apis/logging/v1alpha1/forwarding_types.go#L47, change the `inputType` to `inputSource`

@anpingli PTAL, thanks.