### PR TITLE
Use image with SELinux for cinder SELinux test

### DIFF
--- a/storage/cinder/security/cinder-selinux-fsgroup-test.json
+++ b/storage/cinder/security/cinder-selinux-fsgroup-test.json
@@ -12,7 +12,7 @@
     "containers": [
       {
         "name": "cinder",
-        "image": "aosqe/hello-openshift",
+        "image": "aosqe/storage",
         "ports": [
           {
             "containerPort": 8080,


### PR DESCRIPTION
@chao007 @duanwei33 
Failure [log](http://ci-qe-openshift.usersys.redhat.com/userContent/cucushift/v3/2020/01/10/05:15:39/origin_infra_20_volume_security_testing-cinder-volumeID-cinder/console.html)