### PR TITLE
modify the api of deployment to apps/v1

### DIFF
--- a/svc-catalog/ups-broker-template.yaml
+++ b/svc-catalog/ups-broker-template.yaml
@@ -21,7 +21,7 @@ objects:
       app: ups-broker
     sessionAffinity: None
 
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:


### PR DESCRIPTION
Change the deployment api to apps/v1 since the extensions/v1beta1 no longer useful in OCP 4.4