### PR TITLE
Use image with SELinux

### DIFF
--- a/storage/subpath/iscsi-subpath.json
+++ b/storage/subpath/iscsi-subpath.json
@@ -10,7 +10,7 @@
     "spec": {
 		"initContainers": [{
 			"name": "init",
-			"image": "aosqe/hello-openshift",
+			"image": "aosqe/storage",
 			"command": ["sh", "-c", "mkdir /mnt/iscsi/subpath; cp /hello /mnt/iscsi/subpath/hello"],
 			"volumeMounts": [{
 				"name": "iscsi",
@@ -19,7 +19,7 @@
 		}],
         "containers": [{
             "name": "iscsi",
-            "image": "aosqe/hello-openshift",
+            "image": "aosqe/storage",
             "imagePullPolicy": "IfNotPresent",
             "volumeMounts": [{
                 "name": "iscsi",


### PR DESCRIPTION
Fix automation of OCP-18408, invalid option -- Z to command ls as the image does not have SELinux.