### PR TITLE
add iperf_nodeport_service exposing both TCP and UDP ports

### DIFF
--- a/networking/iperf_nodeport_service.json
+++ b/networking/iperf_nodeport_service.json
@@ -1,0 +1,67 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "iperf-server",
+        "labels": {
+          "name": "iperf-server"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "iperf-server",
+            "image": "bmeng/iperf3",
+            "ports": [
+              {
+                "containerPort": 5201
+              }
+            ],
+            "command": [
+              "iperf3"
+            ],
+            "args": [
+              "-s",
+              "-J"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "iperf-server",
+        "labels": {
+          "name": "iperf-server"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "iperf-tcp",
+            "protocol": "TCP",
+            "port": 5201,
+            "targetPort": 5201
+          },
+          {
+            "name": "iperf-udp",
+            "protocol": "UDP",
+            "port": 5201,
+            "targetPort": 5201
+          }
+        ],
+        "type": "NodePort",
+        "selector": {
+          "name": "iperf-server"
+        }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
We need TCP port for control connection and UDP port for
testing packet loss

use auto nodePort, OpenShift will complain about the service
using the same port or something, but it works having both
UDP and TCP in the same service

Used for OVN tests:

https://github.com/openshift/verification-tests/pull/767