### PR TITLE
Changing the image name to work with normal user

### DIFF
--- a/scheduler/pod_ocp12489.yaml
+++ b/scheduler/pod_ocp12489.yaml
@@ -7,7 +7,7 @@ labels:
 spec:
  containers:
  - name: pod-request
-   image: gcr.io/google_containers/nginx
+   image: openshift/hello-openshift
    resources:
     requests:
      memory: 2000Mi


### PR DESCRIPTION
Image does not work when a normal user creates a pod using the yaml file, so changing the image name here.