### PR TITLE
[OCP-9698] Update the selinux checking pod

### DIFF
--- a/storage/security/emptydir_selinux.json
+++ b/storage/security/emptydir_selinux.json
@@ -1,0 +1,56 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "emptydir",
+    "creationTimestamp": null,
+    "labels": {
+      "name": "volume-test"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "c1",
+        "image": "aosqe/hello-openshift",
+        "ports": [
+          {
+            "containerPort": 8080,
+            "protocol": "TCP"
+          }
+        ],
+        "resources": {},
+        "volumeMounts": [
+          {
+            "name":"tmp",
+            "mountPath":"/tmp"
+          }
+        ],
+        "terminationMessagePath": "/dev/termination-log",
+        "imagePullPolicy": "IfNotPresent",
+        "securityContext": {
+          "runAsUser": 1000160000,
+          "privileged": false
+        }
+      }
+    ],
+    "securityContext": {
+         "fsGroup": 123456,
+         "supplementalGroups": [654321],
+         "seLinuxOptions": {
+            "level": "s0:c13,c2"
+         }
+    },
+    "volumes": [
+      {
+        "name":"tmp",
+        "emptyDir": {}
+      }
+    ],
+
+    "restartPolicy": "Always",
+    "dnsPolicy": "ClusterFirst",
+    "serviceAccount": ""
+  },
+  "status": {}
+}


### PR DESCRIPTION
Summit new file with one container due to the ports conflict if there are two containers.